### PR TITLE
Db interface(classifiers update)

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,3 +1,4 @@
+DROP VIEW IF EXISTS PostToNormalizeRanked;
 DROP VIEW IF EXISTS RawUserLJRanked;
 DROP VIEW IF EXISTS TagNameToPost;
 DROP VIEW IF EXISTS AllNGramTextUsesPost;
@@ -201,4 +202,11 @@ CREATE VIEW RawUserLJRanked AS (
   FROM RawUserLJ r
   WHERE r.crawler_id IS NULL
         AND r.user_id IS NULL
+);
+
+CREATE VIEW PostToNormalizeRanked AS (
+  SELECT id, row_number() OVER(ORDER BY id)
+  FROM Post
+  WHERE normalizer_id IS NULL
+        AND NOT normalized
 );

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -158,15 +158,17 @@ CREATE TABLE TrigramToPost (
 CREATE VIEW PostLength AS (
   SELECT p.id, coalesce(sum(up.uses_cnt),0) length
   FROM Post p
-  LEFT JOIN UnigramToPost up ON p.id = up.post_id
+    LEFT JOIN UnigramToPost up ON p.id = up.post_id
   WHERE p.normalized
   GROUP BY p.id
 );
 
 CREATE VIEW PostUniqueWordCount AS (
-  SELECT post_id, count(*) count
-  FROM UnigramToPost
-  GROUP BY post_id
+  SELECT p.id, coalesce(count(up.uses_cnt), 0) count
+  FROM Post p
+    LEFT JOIN UnigramToPost up ON p.id = up.post_id
+  WHERE p.normalized
+  GROUP BY p.id
 );
 
 CREATE VIEW AllNGramTexts AS (

--- a/db/src/main/java/db/DBConnector.java
+++ b/db/src/main/java/db/DBConnector.java
@@ -290,7 +290,7 @@ public class DBConnector {
                         "FROM TAG t " +
                         "  JOIN tag_list USING(id);";
         String attr = ",(?)";
-        StringBuilder attrs = new StringBuilder("");
+        StringBuilder attrs = new StringBuilder(postIDs.size() * attr.length());
         for (int i = postIDs.size() - 1; i > 0; i--)
             attrs.append(attr);
         selectTagNamesString = String.format(selectTagNamesString,attrs.toString());
@@ -426,7 +426,7 @@ public class DBConnector {
                         "  JOIN post_list USING(id) " +
                         "WHERE p.normalized;";
         String attr = ",(?)";
-        StringBuilder attrs = new StringBuilder("");
+        StringBuilder attrs = new StringBuilder(tags.size() * attr.length());
         for (int i = tags.size() - 1; i > 0; i--)
             attrs.append(attr);
         selectPostNormalizedIdsString =
@@ -532,7 +532,7 @@ public class DBConnector {
                         "  JOIN post_list USING(post_id) " +
                         "GROUP BY text;";
         String attr = ",(?)";
-        StringBuilder attrs = new StringBuilder("");
+        StringBuilder attrs = new StringBuilder(postIDs.size() * attr.length());
         for (int i = postIDs.size() - 1; i > 0; i--)
             attrs.append(attr);
         selectNGramString = String.format(selectNGramString,attrs.toString());
@@ -597,7 +597,7 @@ public class DBConnector {
                         "FROM " + nGramType.getTableName() + " " +
                         "  JOIN ngram_list USING(id);";
         String attr = ",(?)";
-        StringBuilder attrs = new StringBuilder("");
+        StringBuilder attrs = new StringBuilder(postIDs.size() * attr.length());
         for (int i = postIDs.size() - 1; i > 0; i--)
             attrs.append(attr);
         selectNGramString = String.format(selectNGramString,attrs.toString());

--- a/db/src/main/java/db/DBConnector.java
+++ b/db/src/main/java/db/DBConnector.java
@@ -368,7 +368,7 @@ public class DBConnector {
     }
 
     public int getPostUniqueWordCount(long postId) throws SQLException {
-        String selectUniqueWordCountString = "SELECT count FROM PostUniqueWordCount WHERE post_id = ?;";
+        String selectUniqueWordCountString = "SELECT count FROM PostUniqueWordCount WHERE id = ?;";
         try (
                 Connection con = getConnection();
                 PreparedStatement selectUniqueWordCount = con.prepareStatement(selectUniqueWordCountString)

--- a/db/src/main/java/db/DBConnector.java
+++ b/db/src/main/java/db/DBConnector.java
@@ -59,7 +59,7 @@ public class DBConnector {
         private final String user;
         private final String pass;
         private final int maxConnections;       // 100 - внутреннее ограничение постгрес
-        private final int maxTries;             // TODO число попыток выполнения при временной (*) неудаче (>1)
+        private final int maxTries;             // число попыток выполнения при временной (*) неудаче (>1)
 
         private PGPoolingDataSource connectionPool;
 
@@ -109,6 +109,7 @@ public class DBConnector {
     }
 
     protected boolean checkTable(String tableName) throws SQLException {
+        //noinspection SqlResolve
         String selectTableString = "SELECT * FROM pg_catalog.pg_tables WHERE tablename = ?;";
         try (
                 Connection con = getConnection();
@@ -140,8 +141,8 @@ public class DBConnector {
      * try-with-resources (см., например, метод dropInitDatabase).
      */
     public void closeConnection(Connection connectionToClose) throws SQLException {
-        //noinspection EmptyTryBlock
-        try (Connection autoclose = connectionToClose) {
+        //noinspection EmptyTryBlock,unused
+        try (Connection autoClose = connectionToClose) {
         }
     }
 
@@ -267,6 +268,47 @@ public class DBConnector {
         return result;
     }
 
+    public List<String> getAllTagNames(List<Long> postIDs) throws SQLException {
+        if (postIDs == null)
+            throw new IllegalArgumentException("Expected not null argument");
+        List<String> result = new LinkedList<>();
+        if (postIDs.isEmpty())
+            return result;
+        //noinspection SqlResolve,SqlCheckUsingColumns
+        String selectTagNamesString =
+                "WITH post_list AS ( " +
+                        "    SELECT post_id FROM ( " +
+                        "        VALUES (?) %s " +
+                        "    ) AS post_list(post_id) " +
+                        "), tag_list AS ( " +
+                        "    SELECT tp.tag_id id " +
+                        "    FROM TagToPost tp " +
+                        "      JOIN post_list USING (post_id) " +
+                        "    GROUP BY tp.tag_id " +
+                        ")" +
+                        "SELECT t.text " +
+                        "FROM TAG t " +
+                        "  JOIN tag_list USING(id);";
+        String attr = ",(?)";
+        StringBuilder attrs = new StringBuilder("");
+        for (int i = postIDs.size() - 1; i > 0; i--)
+            attrs.append(attr);
+        selectTagNamesString = String.format(selectTagNamesString,attrs.toString());
+        try (
+                Connection con = getConnection();
+                PreparedStatement selectTagNames = con.prepareStatement(selectTagNamesString)
+        ) {
+            int i = 0;
+            for (long postID : postIDs)
+                selectTagNames.setLong(++i, postID);
+            ResultSet rs = tryQueryTransaction(selectTagNames, "TagNameToPost");
+            if (rs != null)
+                while (rs.next())
+                    result.add(rs.getString(1));
+        }
+        return result;
+    }
+
     public Set<Long> getAllUserPostUrls(String userLJNick) throws SQLException {
         Set<Long> result = new HashSet<>();
         String selectUserPostUrlsString = "SELECT url FROM Post p " +
@@ -326,14 +368,23 @@ public class DBConnector {
         return result;
     }
 
+    @Deprecated
     public List<Long> getAllPostNormalizedIds(String tag1, String tag2) throws SQLException {
         if (tag1 == null || tag2 == null)
             throw new IllegalArgumentException("Expected not null arguments");
         List<Long> result = new LinkedList<>();
         //noinspection SqlResolve
-        String selectPostNormalizedIdsString = "WITH with_tags AS " +
-                "(SELECT post_id FROM TagNameToPost WHERE text IN (VALUES (?), (?))) " +
-                "SELECT id FROM Post p JOIN with_tags wt ON wt.post_id = p.id WHERE p.normalized;";
+        String selectPostNormalizedIdsString =
+                "WITH with_tags AS (" +
+                        "    SELECT post_id " +
+                        "    FROM TagNameToPost " +
+                        "    WHERE text IN (VALUES (?), (?)) " +
+                        ") " +
+                        "SELECT id " +
+                        "FROM Post p " +
+                        "  JOIN with_tags wt ON wt.post_id = p.id " +
+                        "  JOIN unigramtopost USING(post_id)" +            //TODO не особо эффективный JOIN
+                        "WHERE p.normalized;";
         try (
                 Connection con = getConnection();
                 PreparedStatement selectPostNormalizedIds = con.prepareStatement(selectPostNormalizedIdsString)
@@ -349,8 +400,52 @@ public class DBConnector {
         return result;
     }
 
-    // TODO нужна реализация от postUrl+username ?
-    // TODO Для неск постов, скажем, всех постов пользователя?
+    public List<Long> getAllPostNormalizedIds(List<String> tags) throws SQLException {
+        if (tags == null)
+            throw new IllegalArgumentException("Expected not null argument");
+        List<Long> result = new LinkedList<>();
+        if (tags.isEmpty())
+            return result;
+        //noinspection SqlResolve
+        String selectPostNormalizedIdsString =
+                "WITH tag_text_list AS ( " +
+                        "    SELECT text " +
+                        "    FROM ( " +
+                        "           VALUES (?) %s " +
+                        "    ) AS tag_text_list(text) " +
+                        "), post_list AS ( " +
+                        "    SELECT tp.post_id id " +
+                        "    FROM Tag t " +
+                        "      JOIN tag_text_list ttl ON t.text = ttl.text " +
+                        "      JOIN tagtopost tp ON t.id = tp.tag_id " +
+                        "      JOIN unigramtopost USING(post_id) " +            //TODO не особо эффективный JOIN
+                        "    GROUP BY tp.post_id " +
+                        ") " +
+                        "SELECT id " +
+                        "FROM Post p " +
+                        "  JOIN post_list USING(id) " +
+                        "WHERE p.normalized;";
+        String attr = ",(?)";
+        StringBuilder attrs = new StringBuilder("");
+        for (int i = tags.size() - 1; i > 0; i--)
+            attrs.append(attr);
+        selectPostNormalizedIdsString =
+                String.format(selectPostNormalizedIdsString,attrs.toString());
+        try (
+                Connection con = getConnection();
+                PreparedStatement selectPostNormalizedIds = con.prepareStatement(selectPostNormalizedIdsString)
+        ) {
+            int i = 0;
+            for (String tag : tags)
+                selectPostNormalizedIds.setString(++i, tag);
+            ResultSet rs = tryQueryTransaction(selectPostNormalizedIds, "Post");
+            if (rs != null)
+                while (rs.next())
+                    result.add(rs.getLong(1));
+        }
+        return result;
+    }
+
     public int getPostLength(long postId) throws SQLException {
         String selectLengthString = "SELECT length FROM PostLength WHERE post_id = ?;";
         try (
@@ -418,9 +513,47 @@ public class DBConnector {
         return result;
     }
 
+    public List<String> getAllNGramNames(List<Long> postIDs) throws SQLException {
+        if (postIDs == null)
+            throw new IllegalArgumentException("Expected not null argument");
+        List<String> result = new LinkedList<>();
+        if (postIDs.isEmpty())
+            return result;
+        //noinspection SqlResolve
+        String selectNGramString =
+                "WITH post_list AS ( " +
+                        "    SELECT post_id  " +
+                        "    FROM ( " +
+                        "      VALUES (?) %s " +
+                        "    ) AS post_list(post_id) " +
+                        ") " +
+                        "SELECT text  " +
+                        "FROM AllNGramTextUsesPost " +
+                        "  JOIN post_list USING(post_id) " +
+                        "GROUP BY text;";
+        String attr = ",(?)";
+        StringBuilder attrs = new StringBuilder("");
+        for (int i = postIDs.size() - 1; i > 0; i--)
+            attrs.append(attr);
+        selectNGramString = String.format(selectNGramString,attrs.toString());
+        try (
+                Connection con = getConnection();
+                PreparedStatement selectNGram = con.prepareStatement(selectNGramString)
+        ) {
+            int i = 0;
+            for (long postID : postIDs)
+                selectNGram.setLong(++i, postID);
+            ResultSet rs = tryQueryTransaction(selectNGram, "AllNGramTextPost");
+            if (rs != null)
+                while (rs.next())
+                    result.add(rs.getString(1));
+        }
+        return result;
+    }
+
     public List<NGram> getAllNGramNames(long postId, NGramType nGramType) throws SQLException {
         List<NGram> result = new LinkedList<>();
-        @SuppressWarnings("SqlResolve")
+        //noinspection SqlResolve
         String selectNGramString = "SELECT n.text, np.uses_cnt " +
                 "FROM " + nGramType.getTableName() + " n " +
                 "JOIN " + nGramType.getTableToPostName() + " np ON n.id = np.ngram_id " +
@@ -437,6 +570,48 @@ public class DBConnector {
                     i = 0;
                     result.add(new NGram(rs.getString(++i), null, rs.getInt(++i)));
                 }
+        }
+        return result;
+    }
+
+    public List<String> getAllNGramNames(List<Long> postIDs, NGramType nGramType) throws SQLException {
+        if (postIDs == null)
+            throw new IllegalArgumentException("Expected not null argument");
+        List<String> result = new LinkedList<>();
+        if (postIDs.isEmpty())
+            return result;
+        //noinspection SqlResolve
+        String selectNGramString =
+                "WITH post_list AS ( " +
+                        "    SELECT post_id " +
+                        "    FROM ( " +
+                        "      VALUES (?) %s " +
+                        "    ) AS post_list(post_id) " +
+                        "), ngram_list AS ( " +
+                        "    SELECT ngram_id id " +
+                        "    FROM " + nGramType.getTableToPostName() + " " +
+                        "      JOIN post_list USING(post_id) " +
+                        "    GROUP BY ngram_id " +
+                        ") " +
+                        "SELECT text " +
+                        "FROM " + nGramType.getTableName() + " " +
+                        "  JOIN ngram_list USING(id);";
+        String attr = ",(?)";
+        StringBuilder attrs = new StringBuilder("");
+        for (int i = postIDs.size() - 1; i > 0; i--)
+            attrs.append(attr);
+        selectNGramString = String.format(selectNGramString,attrs.toString());
+        try (
+                Connection con = getConnection();
+                PreparedStatement selectNGram = con.prepareStatement(selectNGramString)
+        ) {
+            int i = 0;
+            for (long postID : postIDs)
+                selectNGram.setLong(++i, postID);
+            ResultSet rs = tryQueryTransaction(selectNGram, nGramType.getTableName());
+            if (rs != null)
+                while (rs.next())
+                    result.add(rs.getString(1));
         }
         return result;
     }

--- a/db/src/test/java/DBConnectorTestLearning.java
+++ b/db/src/test/java/DBConnectorTestLearning.java
@@ -64,8 +64,18 @@ public class DBConnectorTestLearning {
         // Создаем коннектор без прав записи в базу
         DBConnector db = new DBConnector(dbName);
 
-        // Возьмем из базы список id всех нормализованных постов
-        List<Long> normalizedIds = db.getAllPostNormalizedIds();
+        // Возьмем из базы список id всех нормализованных постов,
+        // имеющих хоть один из нужных нам тегов
+        List<String> preferredTags = new LinkedList<>();
+        //noinspection SpellCheckingInspection
+        preferredTags.add("foto");
+        preferredTags.add("фото");
+        preferredTags.add("photo");
+        //noinspection UnusedAssignment
+        List<Long> normalizedIds = db.getAllPostNormalizedIds(preferredTags);
+
+        // .. или возьмем из базы список id всех нормализованных постов
+        normalizedIds = db.getAllPostNormalizedIds();
 
         // Если такие нашлись, возьмем один из них для примера
         long postId;
@@ -109,6 +119,15 @@ public class DBConnectorTestLearning {
             System.out.println("\t" + nGram.getText() + "\t" + nGram.getUsesCnt());
         System.out.println("\n============\n");
 
+        // Извлекаем из БД список всех н-грамм для списка постов
+        List<Long> prefferedPosts =
+                normalizedIds.subList(0, Math.min(3,normalizedIds.size()));
+        List<String> allNGramsForPosts = db.getAllNGramNames(prefferedPosts);
+        System.out.println("Getting all nGrams for multiple posts from DB:");
+        for (String nGram : allNGramsForPosts)
+            System.out.println("\t" + nGram);
+        System.out.println("\n============\n");
+
         // Извлекаем из БД список всех, например триграм, для конкретного поста
         List<NGram> nGrams = db.getAllNGramNames(postId, DBConnector.NGramType.TRIGRAM);
         System.out.println("Getting all triGrams by postId=" +
@@ -117,6 +136,13 @@ public class DBConnectorTestLearning {
             System.out.println("\t" + nGram.getText() + "\t" + nGram.getUsesCnt());
         System.out.println("\n============\n");
 
+        // Извлекаем из БД список всех всех, например биграм, для списка постов
+        allNGramsForPosts =
+                db.getAllNGramNames(prefferedPosts, DBConnector.NGramType.DIGRAM);
+        System.out.println("Getting all diGrams for multiple posts from DB:");
+        for (String nGram : allNGramsForPosts)
+            System.out.println("\t" + nGram);
+        System.out.println("\n============\n");
 
         // Извлекаем из БД список всех тегов
         List<String> allTagNames = db.getAllTagNames();
@@ -138,6 +164,15 @@ public class DBConnectorTestLearning {
         allTagNames = db.getAllTagNames(postId);
         System.out.println("Getting all tagNames by postId=" +
                 postId + " from DB:");
+        for (String tagName : allTagNames)
+            System.out.println("\t" + tagName);
+        System.out.println("\n============\n");
+
+        // Извлекаем из БД список всех тегов для набора постов
+        List<Long> listOfPostIDs = normalizedIds
+                .subList(0,Math.min(4,normalizedIds.size()));
+        allTagNames = db.getAllTagNames(listOfPostIDs);
+        System.out.println("Getting all tagNames by list of postIDs from DB:");
         for (String tagName : allTagNames)
             System.out.println("\t" + tagName);
         System.out.println("\n============\n");

--- a/db/src/test/java/DBConnectorTestLearning.java
+++ b/db/src/test/java/DBConnectorTestLearning.java
@@ -64,13 +64,16 @@ public class DBConnectorTestLearning {
         // Создаем коннектор без прав записи в базу
         DBConnector db = new DBConnector(dbName);
 
+        // Возьмем из базы список тегов, встречающихся
+        // в нормализованных постах с определенной частотой
+        List<String> preferredTags = db.getTopNormalizedTagNames(200, 500);
+        System.out.println("Getting most popular in normalized posts tags from DB:");
+        for (String tag : preferredTags)
+            System.out.println("\t" + tag);
+        System.out.println("\n============\n");
+
         // Возьмем из базы список id всех нормализованных постов,
         // имеющих хоть один из нужных нам тегов
-        List<String> preferredTags = new LinkedList<>();
-        //noinspection SpellCheckingInspection
-        preferredTags.add("foto");
-        preferredTags.add("фото");
-        preferredTags.add("photo");
         //noinspection UnusedAssignment
         List<Long> normalizedIds = db.getAllPostNormalizedIds(preferredTags);
 


### PR DESCRIPTION
- Новые методы для более удобной работы классификаторов. Например, выдать нормализованные посты с ненулевым количеством уни-грамм, которые относятся хотя бы к одному из данных тегов
- Примеры использования
- Несколько багфиксов
- Рандом для резервирования постов нормализаторами
