### PR TITLE
TF-IDF

### DIFF
--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -5,6 +5,7 @@ DROP VIEW IF EXISTS AllNGramTextUsesPost;
 DROP VIEW IF EXISTS AllNGramTexts;
 DROP VIEW IF EXISTS PostUniqueWordCount;
 DROP VIEW IF EXISTS PostLength;
+DROP MATERIALIZED VIEW IF EXISTS TFIDFSimple;
 DROP TABLE IF EXISTS TrigramToPost;
 DROP TABLE IF EXISTS DigramToPost;
 DROP TABLE IF EXISTS UnigramToPost;
@@ -156,7 +157,59 @@ CREATE TABLE TrigramToPost (
   PRIMARY KEY (ngram_id, post_id)
 );
 
-CREATE INDEX UnigramToPost_post_index ON UnigramToPost(post_id);
+CREATE MATERIALIZED VIEW TFIDFSimple AS (
+  WITH allNGrams AS (
+    SELECT 1 as type, up.ngram_id, up.post_id, up.uses_cnt, ttp.tag_id
+    FROM unigramtopost up JOIN tagtopost ttp USING(post_id)
+    UNION ALL
+    SELECT 2 as type, dp.ngram_id, dp.post_id, dp.uses_cnt, ttp.tag_id
+    FROM digramtopost dp JOIN tagtopost ttp USING(post_id)
+    UNION ALL
+    SELECT 3 as type, tp.ngram_id, tp.post_id, tp.uses_cnt, ttp.tag_id
+    FROM trigramtopost tp JOIN tagtopost ttp USING(post_id)
+  ),
+      totalWordCountByTag AS (
+        SELECT tag_id, sum(uses_cnt) as val
+        FROM allNGrams
+        GROUP BY tag_id
+    ),
+      wordCountByTag AS (
+        SELECT tag_id, type, ngram_id, sum(uses_cnt) AS val
+        FROM allNGrams
+        GROUP BY tag_id, type, ngram_id
+    ),
+    -- Сейчас учитывается число только тех тегов,
+    -- которые имеют нормализованные посты
+      totalTagCount AS (
+        SELECT count(DISTINCT tag_id) AS val
+        FROM allNGrams
+    ),
+      tagCountByWord AS (
+        SELECT type, ngram_id, count(*) as val
+        FROM allNGrams
+        GROUP BY type, ngram_id
+    )
+  SELECT
+    wCBT.tag_id,
+    wCBT.type,
+    wCBT.ngram_id,
+    wCBT.val :: FLOAT / tWCBT.val AS tf,
+    -- Сейчас логарифм десятичный
+    log((SELECT val FROM totalTagCount) :: FLOAT / tCBW.val) AS idf,
+    (wCBT.val :: FLOAT / tWCBT.val) * (log((SELECT val FROM totalTagCount) :: FLOAT / tCBW.val)) AS tf_idf
+  FROM wordCountByTag wCBT
+    JOIN totalWordCountByTag tWCBT USING (tag_id)
+    JOIN tagCountByWord tCBW USING (type, ngram_id)
+) WITH NO DATA;
+
+REFRESH MATERIALIZED VIEW TFIDFSimple;
+
+CREATE INDEX TagToPost_post_id ON TagToPost (post_id);
+CREATE INDEX TFIDFSimple_tf_idf ON TFIDFSimple (tf_idf);
+CREATE INDEX TFIDFSimple_tag_id ON TFIDFSimple (tag_id);
+CREATE INDEX UnigramToPost_post_id ON UnigramToPost (post_id);
+CREATE INDEX DigramToPost_post_id ON DigramToPost (post_id);
+CREATE INDEX TrigramToPost_post_id ON TrigramToPost (post_id);
 
 CREATE VIEW PostLength AS (
   SELECT p.id, coalesce(sum(up.uses_cnt),0) length

--- a/src/main/resources/db/schemaOnlineUpdate.sql
+++ b/src/main/resources/db/schemaOnlineUpdate.sql
@@ -78,25 +78,22 @@ ALTER TABLE Post ALTER COLUMN url SET DATA TYPE BIGINT USING (url::BIGINT);
 -- =======================================
 -- 16_02_26
 
-CREATE INDEX unigram_to_post ON unigramtopost(post_id);
-CREATE INDEX digram_to_post ON digramtopost(post_id);
-CREATE INDEX trigram_to_post ON trigramtopost(post_id);
-CREATE INDEX tag_to_post ON tagtopost(post_id);
-CREATE INDEX tf_idf_test_tf_idf ON tf_idf_test(tf_idf);
+CREATE INDEX DigramToPost_post_id ON DigramToPost (post_id);
+CREATE INDEX TrigramToPost_post_id ON TrigramToPost (post_id);
+CREATE INDEX TagToPost_post_id ON TagToPost (post_id);
+CREATE INDEX TFIDFSimple_tag_id ON TFIDFSimple (tag_id);
+CREATE INDEX TFIDFSimple_tf_idf ON TFIDFSimple (tf_idf);
 
-CREATE MATERIALIZED VIEW tf_idf_test AS (
+CREATE MATERIALIZED VIEW TFIDFSimple AS (
   WITH allNGrams AS (
     SELECT 1 as type, up.ngram_id, up.post_id, up.uses_cnt, ttp.tag_id
     FROM unigramtopost up JOIN tagtopost ttp USING(post_id)
-    --     JOIN unigram u ON up.ngram_id = u.id
     UNION ALL
     SELECT 2 as type, dp.ngram_id, dp.post_id, dp.uses_cnt, ttp.tag_id
     FROM digramtopost dp JOIN tagtopost ttp USING(post_id)
-    --     JOIN digram d ON dp.ngram_id = d.id
     UNION ALL
     SELECT 3 as type, tp.ngram_id, tp.post_id, tp.uses_cnt, ttp.tag_id
     FROM trigramtopost tp JOIN tagtopost ttp USING(post_id)
-    --     JOIN trigram t ON tp.ngram_id = t.id
   ),
       totalWordCountByTag AS (
         SELECT tag_id, sum(uses_cnt) as val
@@ -104,14 +101,14 @@ CREATE MATERIALIZED VIEW tf_idf_test AS (
         GROUP BY tag_id
     ),
       wordCountByTag AS (
-        SELECT tag_id, type, ngram_id, sum(uses_cnt) as val
+        SELECT tag_id, type, ngram_id, sum(uses_cnt) AS val
         FROM allNGrams
         GROUP BY tag_id, type, ngram_id
     ),
     -- Сейчас учитывается число только тех тегов,
     -- которые имеют нормализованные посты
       totalTagCount AS (
-        SELECT count(DISTINCT tag_id) as val
+        SELECT count(DISTINCT tag_id) AS val
         FROM allNGrams
     ),
       tagCountByWord AS (
@@ -125,11 +122,11 @@ CREATE MATERIALIZED VIEW tf_idf_test AS (
     wCBT.ngram_id,
     wCBT.val :: FLOAT / tWCBT.val AS tf,
     -- Сейчас логарифм десятичный
-    log((SELECT val FROM totalTagCount)::FLOAT / tCBW.val) AS idf,
-    (wCBT.val :: FLOAT / tWCBT.val) * (log((SELECT val FROM totalTagCount)::FLOAT / tCBW.val)) as tf_idf
+    log((SELECT val FROM totalTagCount) :: FLOAT / tCBW.val) AS idf,
+    (wCBT.val :: FLOAT / tWCBT.val) * (log((SELECT val FROM totalTagCount) :: FLOAT / tCBW.val)) AS tf_idf
   FROM wordCountByTag wCBT
-    JOIN totalWordCountByTag tWCBT USING(tag_id)
-    JOIN tagCountByWord tCBW USING(type, ngram_id)
-);
+    JOIN totalWordCountByTag tWCBT USING (tag_id)
+    JOIN tagCountByWord tCBW USING (type, ngram_id)
+) WITH NO DATA;
 
--- REFRESH MATERIALIZED VIEW tf_idf_test;
+REFRESH MATERIALIZED VIEW TFIDFSimple;

--- a/src/test/java/com/interestscsc/db/test/DBConnectorTestLearning.java
+++ b/src/test/java/com/interestscsc/db/test/DBConnectorTestLearning.java
@@ -159,6 +159,42 @@ public class DBConnectorTestLearning {
         System.out.println("\n============\n");
 
         /**
+         * Обновляем материализованное представление в БД.
+         *
+         * Если после последнего такого обновления, например представления tf-idf,
+         * были нормализованны новые посты, для обновления информации в TFIDFSimple
+         * необходимо вызвать этот метод.
+         */
+        System.out.println("Started an update of TF-IDF Materialized View. Please wait.");
+        db.refreshMaterializedView(DBConnector.MaterializedView.TFIDFSimple);
+        System.out.println("Update complete.");
+        System.out.println("\n============\n");
+
+        /**
+         * Извлекаем из БД список н-грамм, связанных с заданным списком тегов
+         * {@code preferredTags} и максимальным значением tf-idf-simple, ограничивая
+         * число выдаваемых н-грамм по {@code perTagLimit} на каждый тег.
+         */
+        int perTagLimit = 10;
+        allNGramNames = db.getTFIDFTopNGramNamesByPerTagLimit(preferredTags, perTagLimit);
+        System.out.println(String.format("Getting TF-IDF-Top nGramNames from DB - max %d per tag:", perTagLimit));
+        for (String nGramName : allNGramNames)
+            System.out.println("\t" + nGramName);
+        System.out.println("\n============\n");
+
+        /**
+         * Извлекаем из БД список н-грамм связанных с заданным списком тегов
+         * {@code preferredTags} и максимальным значением tf-idf-simple, ограничивая
+         * общее число выдаваемых н-грамм по {@code maxNGramNum}.
+         */
+        int maxNGramNum = 10;
+        allNGramNames = db.getTFIDFTopNGramNamesByTotalLimit(preferredTags, maxNGramNum);
+        System.out.println(String.format("Getting TF-IDF-Top nGramNames from DB - max %d totally:", maxNGramNum));
+        for (String nGramName : allNGramNames)
+            System.out.println("\t" + nGramName);
+        System.out.println("\n============\n");
+
+        /**
          * Извлекаем из БД список всех н-грамм для списка постов
          */
         List<String> allNGramNamesForPosts = db.getAllNGramNames(selectedPosts);


### PR DESCRIPTION
- Материализованное представление TFIDFSimple для быстрого расчета и использования tf-idf
- Метод для обновления TFIDFSimple
- Два метода отбора н-грамм на основе TF-IDF (подробнее см. javadoc):
  - `getTFIDFTopNGramNamesByPerTagLimit` - задаем максимальное количество выдаваемых н-грамм для тега
  - `getTFIDFTopNGramNamesByTotalLimit` - задаем общий лимит возвращаемого количества н-грамм, распределение числа по тегам происходит согласно числу н-грамм, представляющих тег. (процентное распределение)
- примеры использования
